### PR TITLE
Fix thumbnailing and average image color calculation

### DIFF
--- a/gdg/scrape.py
+++ b/gdg/scrape.py
@@ -88,6 +88,17 @@ def scrape_images():
             make_thumbnail(i)
             derive_average_color(i)
 
+def normalize_image(image):
+# ensures passed in PIL.Image is RGB
+    # If the image isn't RGB, convert it to RGB.
+    if (image.mode != "RGB"):
+        try:
+            image = image.convert("RGB")
+        except Exception as ex:
+            print("RGB conversion error for image " + i.path + ": " + str(ex))
+    return image
+
+
 def extract_image_metadata(i):
 # function determines image dimensions
     try:
@@ -107,13 +118,7 @@ def make_thumbnail(i):
     try:
         print("Thumbnailing image " + i.path)
         img = PIL.Image.open(i.path)
-       
-        # If the image isn't RGB, convert it to RGB.
-        if (img.mode != "RGB"):
-            try:
-                img = img.convert("RGB")
-            except Exception as ex:
-                print("RGB conversion error for image " + i.path + ": " + str(ex))
+        img = normalize_image(img)
 
         x = 0
         w = min(img.size)
@@ -159,13 +164,7 @@ def derive_average_color(i):
     try:
         print("Getting average color of image " + i.path)
         img = PIL.Image.open(i.path)
-
-        # If the image isn't RGB, convert it to RGB.
-        if (img.mode != "RGB"):
-            try:
-                img = img.convert("RGB")
-            except Exception as ex:
-                print("RGB conversion error for image " + i.path + ": " + str(ex))
+        img = normalize_image(img)
         
         hist = img.histogram()
         r = hist[0:256]


### PR DESCRIPTION
This should resolve issue #6. I suspect that there's performance gains to be had by not converting to RGB in the average color calculation, but that's a future optimization.
